### PR TITLE
pin-382: Add 'clients' prefix to keys routes

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -251,7 +251,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  '/{clientId}/keys':
+  '/clients/{clientId}/keys':
     post:
       tags:
         - key
@@ -319,8 +319,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-
-  '/{clientId}/keys/{keyId}':
+  '/clients/{clientId}/keys/{keyId}':
     get:
       tags:
         - key
@@ -383,7 +382,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  '/{clientId}/keys/{keyId}/disable':
+  '/clients/{clientId}/keys/{keyId}/disable':
     get:
       tags:
         - key
@@ -413,7 +412,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Problem'
-  '/{clientId}/keys/{keyId}/enable':
+  '/clients/{clientId}/keys/{keyId}/enable':
     get:
       tags:
         - key

--- a/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/SpecHelper.scala
+++ b/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/SpecHelper.scala
@@ -142,7 +142,7 @@ trait SpecHelper extends SpecConfiguration with MockFactory with SprayJsonSuppor
          |]
          |""".stripMargin
 
-    val response = request(uri = s"$serviceURL/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
+    val response = request(uri = s"$serviceURL/clients/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
 
     response.status shouldBe StatusCodes.Created
 

--- a/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/ClientManagementSpec.scala
+++ b/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/ClientManagementSpec.scala
@@ -86,7 +86,7 @@ class ClientManagementSpec
       val retrieveClientResponse = request(uri = s"$serviceURL/clients/$clientUuid", method = HttpMethods.GET)
       retrieveClientResponse.status shouldBe StatusCodes.NotFound
 
-      val retrieveKeysResponse = request(uri = s"$serviceURL/$clientUuid/keys", method = HttpMethods.GET)
+      val retrieveKeysResponse = request(uri = s"$serviceURL/clients/$clientUuid/keys", method = HttpMethods.GET)
       retrieveKeysResponse.status shouldBe StatusCodes.NotFound
     }
 

--- a/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/KeyManagementSpec.scala
+++ b/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/KeyManagementSpec.scala
@@ -41,7 +41,7 @@ class KeyManagementSpec
            |""".stripMargin
 
       val response =
-        request(uri = s"$serviceURL/non-existing-client-id/keys", method = HttpMethods.POST, data = Some(data))
+        request(uri = s"$serviceURL/clients/non-existing-client-id/keys", method = HttpMethods.POST, data = Some(data))
 
       response.status shouldBe StatusCodes.BadRequest
     }
@@ -65,7 +65,7 @@ class KeyManagementSpec
            |""".stripMargin
 
       val response =
-        request(uri = s"$serviceURL/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
+        request(uri = s"$serviceURL/clients/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
 
       response.status shouldBe StatusCodes.BadRequest
     }
@@ -91,7 +91,7 @@ class KeyManagementSpec
            |""".stripMargin
 
       val response =
-        request(uri = s"$serviceURL/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
+        request(uri = s"$serviceURL/clients/${clientId.toString}/keys", method = HttpMethods.POST, data = Some(data))
 
       response.status shouldBe StatusCodes.Created
     }

--- a/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/OperatorManagementSpec.scala
+++ b/src/test/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/impl/OperatorManagementSpec.scala
@@ -89,7 +89,7 @@ class OperatorManagementSpec
       val retrievedClient        = Await.result(Unmarshal(clientRetrieveResponse).to[Client], Duration.Inf)
       retrievedClient.operators shouldBe Set(operatorId2)
 
-      val keysRetrieveResponse = request(uri = s"$serviceURL/$clientId/keys", method = HttpMethods.GET)
+      val keysRetrieveResponse = request(uri = s"$serviceURL/clients/$clientId/keys", method = HttpMethods.GET)
       val retrievedKeys        = Await.result(Unmarshal(keysRetrieveResponse).to[KeysResponse], Duration.Inf)
       retrievedKeys.keys shouldBe operator2Keys.keys
     }
@@ -116,7 +116,7 @@ class OperatorManagementSpec
       val retrievedClient        = Await.result(Unmarshal(clientRetrieveResponse).to[Client], Duration.Inf)
       retrievedClient.operators shouldBe Set(operatorId)
 
-      val keysRetrieveResponse = request(uri = s"$serviceURL/$clientId2/keys", method = HttpMethods.GET)
+      val keysRetrieveResponse = request(uri = s"$serviceURL/clients/$clientId2/keys", method = HttpMethods.GET)
       val retrievedKeys        = Await.result(Unmarshal(keysRetrieveResponse).to[KeysResponse], Duration.Inf)
       retrievedKeys.keys shouldBe client2Keys.keys
     }


### PR DESCRIPTION
Example
`/{clientId}/keys` -> `/clients/{clientId}/keys`