### PR TITLE
pin-522: Add status to key api response

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -346,7 +346,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Key'
+                $ref: '#/components/schemas/ClientKey'
         '404':
           description: Key not found
           content:
@@ -450,7 +450,7 @@ components:
         keys:
           type: array
           items:
-            $ref: '#/components/schemas/Key'
+            $ref: '#/components/schemas/ClientKey'
       required:
         - keys
     Keys:
@@ -482,6 +482,18 @@ components:
         - key
         - use
         - alg
+    ClientKey:
+      type: object
+      properties:
+        key:
+          $ref: '#/components/schemas/Key'
+        status:
+          type: string
+          description: 'Key status'
+          enum: [ 'active', 'disabled', 'deleted' ]
+      required:
+        - key
+        - status
     Key:
       description: 'Models a JWK'
       type: object

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/KeyApiMarshallerImpl.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/KeyApiMarshallerImpl.scala
@@ -4,14 +4,14 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
 import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import it.pagopa.pdnd.interop.uservice.keymanagement.api.KeyApiMarshaller
-import it.pagopa.pdnd.interop.uservice.keymanagement.model.{Key, KeySeed, KeysResponse, Problem}
+import it.pagopa.pdnd.interop.uservice.keymanagement.model.{ClientKey, KeySeed, KeysResponse, Problem}
 import spray.json._
 
 class KeyApiMarshallerImpl extends KeyApiMarshaller with SprayJsonSupport with DefaultJsonProtocol {
   override implicit def fromEntityUnmarshallerKeySeedList: FromEntityUnmarshaller[Seq[KeySeed]] =
     sprayJsonUnmarshaller[Seq[KeySeed]]
-  override implicit def toEntityMarshallerKey: ToEntityMarshaller[Key] = sprayJsonMarshaller[Key]
   override implicit def toEntityMarshallerKeysResponse: ToEntityMarshaller[KeysResponse] =
     sprayJsonMarshaller[KeysResponse]
-  override implicit def toEntityMarshallerProblem: ToEntityMarshaller[Problem] = sprayJsonMarshaller[Problem]
+  override implicit def toEntityMarshallerProblem: ToEntityMarshaller[Problem]     = sprayJsonMarshaller[Problem]
+  override implicit def toEntityMarshallerClientKey: ToEntityMarshaller[ClientKey] = sprayJsonMarshaller[ClientKey]
 }

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/KeyApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/KeyApiServiceImpl.scala
@@ -14,7 +14,7 @@ import it.pagopa.pdnd.interop.uservice.keymanagement.api.KeyApiService
 import it.pagopa.pdnd.interop.uservice.keymanagement.common.system._
 import it.pagopa.pdnd.interop.uservice.keymanagement.model.persistence._
 import it.pagopa.pdnd.interop.uservice.keymanagement.model.persistence.impl.Validation
-import it.pagopa.pdnd.interop.uservice.keymanagement.model.{Key, KeySeed, KeysResponse, Problem}
+import it.pagopa.pdnd.interop.uservice.keymanagement.model.{ClientKey, KeySeed, KeysResponse, Problem}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
@@ -99,14 +99,14 @@ class KeyApiServiceImpl(
     * Code: 404, Message: Key not found, DataType: Problem
     */
   override def getClientKeyById(clientId: String, keyId: String)(implicit
-    toEntityMarshallerKey: ToEntityMarshaller[Key],
+    toEntityMarshallerClientKey: ToEntityMarshaller[ClientKey],
     toEntityMarshallerProblem: ToEntityMarshaller[Problem]
   ): Route = {
     logger.info(s"Getting key ${keyId} for client ${clientId}...")
     val commander: EntityRef[Command] =
       sharding.entityRefFor(KeyPersistentBehavior.TypeKey, getShard(clientId, settings.numberOfShards))
 
-    val result: Future[StatusReply[Key]] = commander.ask(ref => GetKey(clientId, keyId, ref))
+    val result: Future[StatusReply[ClientKey]] = commander.ask(ref => GetKey(clientId, keyId, ref))
 
     onSuccess(result) {
       case statusReply if statusReply.isSuccess => getClientKeyById200(statusReply.getValue)

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/api/impl/package.scala
@@ -3,6 +3,7 @@ package it.pagopa.pdnd.interop.uservice.keymanagement.api
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import it.pagopa.pdnd.interop.uservice.keymanagement.model.{
   Client,
+  ClientKey,
   ClientSeed,
   Key,
   KeySeed,
@@ -40,6 +41,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val otherPrimeInfoFormat: RootJsonFormat[OtherPrimeInfo] = jsonFormat3(OtherPrimeInfo)
   implicit val keySeedFormat: RootJsonFormat[KeySeed]               = jsonFormat4(KeySeed)
   implicit val keyFormat: RootJsonFormat[Key]                       = customKeyFormat
+  implicit val clientKeyFormat: RootJsonFormat[ClientKey]           = jsonFormat2(ClientKey)
   implicit val keyResponseFormat: RootJsonFormat[KeysResponse]      = jsonFormat1(KeysResponse)
 
   implicit val clientSeedFormat: RootJsonFormat[ClientSeed]     = jsonFormat4(ClientSeed)

--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/commands.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/commands.scala
@@ -4,7 +4,7 @@ import akka.Done
 import akka.actor.typed.ActorRef
 import akka.pattern.StatusReply
 import it.pagopa.pdnd.interop.uservice.keymanagement.model.persistence.client.PersistentClient
-import it.pagopa.pdnd.interop.uservice.keymanagement.model.{Key, KeysResponse}
+import it.pagopa.pdnd.interop.uservice.keymanagement.model.{ClientKey, KeysResponse}
 
 import java.util.UUID
 
@@ -12,12 +12,12 @@ sealed trait Command
 
 final case class AddKeys(clientId: String, keys: Seq[ValidKey], replyTo: ActorRef[StatusReply[KeysResponse]])
     extends Command
-final case class GetKeys(clientId: String, replyTo: ActorRef[StatusReply[KeysResponse]])           extends Command
-final case class GetKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Key]])      extends Command
-final case class DisableKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]]) extends Command
-final case class EnableKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]])  extends Command
-final case class DeleteKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]])  extends Command
-final case class ListKid(from: Int, until: Int, replyTo: ActorRef[StatusReply[Seq[Kid]]])          extends Command
+final case class GetKeys(clientId: String, replyTo: ActorRef[StatusReply[KeysResponse]])            extends Command
+final case class GetKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[ClientKey]]) extends Command
+final case class DisableKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]])  extends Command
+final case class EnableKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]])   extends Command
+final case class DeleteKey(clientId: String, keyId: String, replyTo: ActorRef[StatusReply[Done]])   extends Command
+final case class ListKid(from: Int, until: Int, replyTo: ActorRef[StatusReply[Seq[Kid]]])           extends Command
 
 final case class AddClient(client: PersistentClient, replyTo: ActorRef[StatusReply[PersistentClient]]) extends Command
 final case class GetClient(clientId: String, replyTo: ActorRef[StatusReply[PersistentClient]])         extends Command


### PR DESCRIPTION
This PR exposes the persisted status to the API response.

The current returned `Key` is compliant to JWK standard, so its model has not been changed.
Instead, the existing `Key` has been encapsulated in the new object `ClientKey`, which contains the status.