### PR TITLE
pin-586: Keys retrieve return all keys (not only active ones)

### DIFF
--- a/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/KeyPersistentBehavior.scala
+++ b/src/main/scala/it/pagopa/pdnd/interop/uservice/keymanagement/model/persistence/KeyPersistentBehavior.scala
@@ -107,7 +107,7 @@ object KeyPersistentBehavior {
         }
 
       case GetKeys(clientId, replyTo) =>
-        state.getClientActiveKeys(clientId) match {
+        state.keys.get(clientId) match {
           case Some(keys) =>
             toAPIResponse(keys).fold(
               error => errorMessageReply(replyTo, s"Error while retrieving keys: ${error.getLocalizedMessage}"),


### PR DESCRIPTION
I didn't see any logic that should be impacted by this change, but let me know