### PR TITLE
pin-1612: Refactor clients purposes from map to seq

### DIFF
--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
@@ -1,14 +1,12 @@
 package it.pagopa.interop.authorizationmanagement.model.client
 
-import it.pagopa.interop.authorizationmanagement.model.client.PersistentClientPurposes.PersistentClientPurposes
-
 import java.util.UUID
 
 final case class PersistentClient(
   id: UUID,
   consumerId: UUID,
   name: String,
-  purposes: PersistentClientPurposes,
+  purposes: Seq[PersistentClientStatesChain],
   description: Option[String],
   relationships: Set[UUID],
   kind: PersistentClientKind

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClientPurpose.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClientPurpose.scala
@@ -1,5 +1,3 @@
 package it.pagopa.interop.authorizationmanagement.model.client
 
-import java.util.UUID
-
-final case class PersistentClientPurpose(id: UUID, statesChain: PersistentClientStatesChain)
+final case class PersistentClientPurpose(statesChain: PersistentClientStatesChain)

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClientPurposes.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClientPurposes.scala
@@ -1,6 +1,0 @@
-package it.pagopa.interop.authorizationmanagement.model.client
-
-object PersistentClientPurposes {
-  type PurposeId                = String
-  type PersistentClientPurposes = Map[PurposeId, PersistentClientStatesChain]
-}

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/events.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/events.scala
@@ -21,9 +21,8 @@ final case class ClientDeleted(clientId: String)       extends Event
 final case class RelationshipAdded(client: PersistentClient, relationshipId: UUID) extends Event
 final case class RelationshipRemoved(clientId: String, relationshipId: String)     extends Event
 
-final case class ClientPurposeAdded(clientId: String, purposeId: String, statesChain: PersistentClientStatesChain)
-    extends Event
-final case class ClientPurposeRemoved(clientId: String, purposeId: String) extends Event
+final case class ClientPurposeAdded(clientId: String, statesChain: PersistentClientStatesChain) extends Event
+final case class ClientPurposeRemoved(clientId: String, purposeId: String)                      extends Event
 
 final case class EServiceStateUpdated(
   eServiceId: String,

--- a/src/main/protobuf/v1/client.proto
+++ b/src/main/protobuf/v1/client.proto
@@ -18,8 +18,7 @@ message PersistentClientV1 {
 }
 
 message ClientPurposesEntryV1 {
-  required string purposeId = 1;
-  required ClientStatesChainV1 states = 2;
+  required ClientStatesChainV1 states = 1;
 }
 
 message ClientStatesChainV1 {

--- a/src/main/protobuf/v1/events.proto
+++ b/src/main/protobuf/v1/events.proto
@@ -40,8 +40,7 @@ message RelationshipRemovedV1 {
 
 message ClientPurposeAddedV1 {
   required string clientId = 1;
-  required string purposeId = 2;
-  required ClientStatesChainV1 statesChain = 3;
+  required ClientStatesChainV1 statesChain = 2;
 }
 
 message ClientPurposeRemovedV1 {

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -917,24 +917,16 @@ components:
     Purpose:
       type: object
       properties:
-        purposeId:
-          type: string
-          format: uuid
         states:
           $ref: '#/components/schemas/ClientStatesChain'
       required:
-        - purposeId
         - states
     PurposeSeed:
       type: object
       properties:
-        purposeId:
-          type: string
-          format: uuid
         states:
           $ref: '#/components/schemas/ClientStatesChainSeed'
       required:
-        - purposeId
         - states
     ClientStatesChain:
       type: object

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/PurposeApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/PurposeApiServiceImpl.scala
@@ -66,13 +66,19 @@ final case class PurposeApiServiceImpl(
           case err                      =>
             logger.error(s"Error adding Purpose for Client $clientId", err)
             val problem =
-              problemOf(StatusCodes.InternalServerError, ClientPurposeAdditionError(clientId, seed.purposeId.toString))
+              problemOf(
+                StatusCodes.InternalServerError,
+                ClientPurposeAdditionError(clientId, seed.states.purpose.purposeId.toString)
+              )
             complete(problem.status, problem)
         }
       case Failure(ex)                                   =>
         logger.error(s"Error adding Purpose for Client $clientId", ex)
         val problem =
-          problemOf(StatusCodes.InternalServerError, ClientPurposeAdditionError(clientId, seed.purposeId.toString))
+          problemOf(
+            StatusCodes.InternalServerError,
+            ClientPurposeAdditionError(clientId, seed.states.purpose.purposeId.toString)
+          )
         complete(problem.status, problem)
     }
   }

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/TokenGenerationApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/TokenGenerationApiServiceImpl.scala
@@ -49,11 +49,10 @@ final case class TokenGenerationApiServiceImpl(
 
     onSuccess(result) {
       case statusReply if statusReply.isSuccess =>
-        val (persistentClient, persistentKey)        = statusReply.getValue
-        val result: Either[Throwable, KeyWithClient] = for {
-          apiClient <- persistentClient.toApi
-          apiKey    <- persistentKey.toApi
-        } yield KeyWithClient(key = apiKey.key, client = apiClient)
+        val (persistentClient, persistentKey) = statusReply.getValue
+
+        val result: Either[Throwable, KeyWithClient] =
+          persistentKey.toApi.map(apiKey => KeyWithClient(key = apiKey.key, client = persistentClient.toApi))
 
         result.fold(err => internalServerError("Key with Client retrieve", err.getMessage), getKeyWithClientByKeyId200)
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/package.scala
@@ -30,7 +30,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val clientEServiceDetailsFormat: RootJsonFormat[ClientEServiceDetails]   = jsonFormat5(ClientEServiceDetails)
   implicit val clientPurposeDetailsFormat: RootJsonFormat[ClientPurposeDetails]     = jsonFormat3(ClientPurposeDetails)
   implicit val clientStatesChainFormat: RootJsonFormat[ClientStatesChain]           = jsonFormat4(ClientStatesChain)
-  implicit val purposeFormat: RootJsonFormat[Purpose]                               = jsonFormat2(Purpose)
+  implicit val purposeFormat: RootJsonFormat[Purpose]                               = jsonFormat1(Purpose)
 
   implicit val eServiceDetailsSeedFormat: RootJsonFormat[ClientEServiceDetailsSeed]   =
     jsonFormat5(ClientEServiceDetailsSeed)
@@ -39,7 +39,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val purposeDetailsSeedFormat: RootJsonFormat[ClientPurposeDetailsSeed]     =
     jsonFormat3(ClientPurposeDetailsSeed)
   implicit val statesChainSeedFormat: RootJsonFormat[ClientStatesChainSeed] = jsonFormat3(ClientStatesChainSeed)
-  implicit val purposeSeedFormat: RootJsonFormat[PurposeSeed]               = jsonFormat2(PurposeSeed)
+  implicit val purposeSeedFormat: RootJsonFormat[PurposeSeed]               = jsonFormat1(PurposeSeed)
 
   implicit val eServiceDetailsUpdateFormat: RootJsonFormat[ClientEServiceDetailsUpdate]   =
     jsonFormat4(ClientEServiceDetailsUpdate)

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/authz/PurposeApiServiceAuthzSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/authz/PurposeApiServiceAuthzSpec.scala
@@ -31,9 +31,8 @@ class PurposeApiServiceAuthzSpec extends AnyWordSpecLike with ClusteredScalatest
     "accept authorized roles for addClientPurpose" in {
       val endpoint = AuthorizedRoutes.endpoints("addClientPurpose")
 
-      val fakeSeed = PurposeSeed(
-        purposeId = UUID.randomUUID(),
-        states = ClientStatesChainSeed(
+      val fakeSeed = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = UUID.randomUUID(),
             descriptorId = UUID.randomUUID(),

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
@@ -101,9 +101,8 @@ class ClientManagementSpec
 
       (() => mockUUIDSupplier.get).expects().returning(statesChainId).once()
 
-      val payload1 = PurposeSeed(
-        purposeId = purposeId1,
-        states = ClientStatesChainSeed(
+      val payload1 = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -125,9 +124,8 @@ class ClientManagementSpec
         )
       )
 
-      val payload2 = PurposeSeed(
-        purposeId = purposeId2,
-        states = ClientStatesChainSeed(
+      val payload2 = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -174,9 +172,8 @@ class ClientManagementSpec
           description = Some(s"New Client ${clientId.toString} description"),
           kind = ClientKind.CONSUMER,
           purposes = Seq(
-            Purpose(
-              purposeId = purposeId1,
-              states = ClientStatesChain(
+            Purpose(states =
+              ClientStatesChain(
                 id = statesChainId,
                 eservice = ClientEServiceDetails(
                   eserviceId = eServiceId,
@@ -225,9 +222,8 @@ class ClientManagementSpec
 
       (() => mockUUIDSupplier.get).expects().returning(statesChainId).once()
 
-      val payload = PurposeSeed(
-        purposeId = purposeId,
-        states = ClientStatesChainSeed(
+      val payload = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -356,30 +352,43 @@ class ClientManagementSpec
       createClient(clientId2, consumerId)
       createClient(clientId3, consumerId)
 
-      val purposeSeed1 = PurposeSeed(
+      val eServiceDetailsSeed = ClientEServiceDetailsSeed(
+        eserviceId = UUID.randomUUID(),
+        descriptorId = UUID.randomUUID(),
+        state = ACTIVE,
+        audience = Seq("some.audience"),
+        voucherLifespan = 10
+      )
+
+      val agreementDetailsSeed = ClientAgreementDetailsSeed(
+        eserviceId = UUID.randomUUID(),
+        consumerId = UUID.randomUUID(),
+        agreementId = UUID.randomUUID(),
+        state = INACTIVE
+      )
+
+      val purposeDetailsSeed1 = ClientPurposeDetailsSeed(
         purposeId = purposeId1,
-        states = ClientStatesChainSeed(
-          eservice = ClientEServiceDetailsSeed(
-            eserviceId = UUID.randomUUID(),
-            descriptorId = UUID.randomUUID(),
-            state = ACTIVE,
-            audience = Seq("some.audience"),
-            voucherLifespan = 10
-          ),
-          agreement = ClientAgreementDetailsSeed(
-            eserviceId = UUID.randomUUID(),
-            consumerId = UUID.randomUUID(),
-            agreementId = UUID.randomUUID(),
-            state = INACTIVE
-          ),
-          purpose = ClientPurposeDetailsSeed(
-            purposeId = purposeId1,
-            versionId = purposeVersionId1,
-            state = ClientComponentState.ACTIVE
-          )
+        versionId = purposeVersionId1,
+        state = ClientComponentState.ACTIVE
+      )
+
+      val purposeSeed1 = PurposeSeed(states =
+        ClientStatesChainSeed(
+          eservice = eServiceDetailsSeed,
+          agreement = agreementDetailsSeed,
+          purpose = purposeDetailsSeed1.copy(purposeId = purposeId1)
         )
       )
-      val purposeSeed2 = purposeSeed1.copy(purposeId = purposeId2)
+
+      val purposeSeed2 =
+        PurposeSeed(states =
+          ClientStatesChainSeed(
+            eservice = eServiceDetailsSeed,
+            agreement = agreementDetailsSeed,
+            purpose = purposeDetailsSeed1.copy(purposeId = purposeId2)
+          )
+        )
 
       addPurposeState(clientId1, purposeSeed1, UUID.randomUUID())
       addPurposeState(clientId2, purposeSeed1, UUID.randomUUID())

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/PurposeManagementSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/PurposeManagementSpec.scala
@@ -49,9 +49,8 @@ class PurposeManagementSpec
 
       (() => mockUUIDSupplier.get).expects().returning(statesChainId).once()
 
-      val expected = Purpose(
-        purposeId = purposeId,
-        states = ClientStatesChain(
+      val expected = Purpose(states =
+        ClientStatesChain(
           id = statesChainId,
           eservice = ClientEServiceDetails(
             eserviceId = eServiceId,
@@ -74,9 +73,8 @@ class PurposeManagementSpec
         )
       )
 
-      val payload = PurposeSeed(
-        purposeId = purposeId,
-        states = ClientStatesChainSeed(
+      val payload = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -124,9 +122,8 @@ class PurposeManagementSpec
 
       (() => mockUUIDSupplier.get).expects().returning(statesChainId).once()
 
-      val payload = PurposeSeed(
-        purposeId = purposeId,
-        states = ClientStatesChainSeed(
+      val payload = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -175,9 +172,8 @@ class PurposeManagementSpec
       val purposeVersionId = UUID.randomUUID()
 
       val statesChainId = UUID.randomUUID()
-      val payload       = PurposeSeed(
-        purposeId = purposeId,
-        states = ClientStatesChainSeed(
+      val payload       = PurposeSeed(states =
+        ClientStatesChainSeed(
           eservice = ClientEServiceDetailsSeed(
             eserviceId = eServiceId,
             descriptorId = descriptorId,
@@ -248,38 +244,39 @@ class PurposeManagementSpec
       val statesChainId4 = UUID.randomUUID()
 
       // Seed
-      val eService1Seed = ClientEServiceDetailsSeed(
+      val eService1Seed                = ClientEServiceDetailsSeed(
         eserviceId = eServiceId1,
         descriptorId = descriptorId1,
         state = ClientComponentState.ACTIVE,
         audience = Seq("some.audience"),
         voucherLifespan = 10
       )
-      val eService2Seed = eService1Seed.copy(eserviceId = eServiceId2, descriptorId = descriptorId2)
-      val agreementSeed = ClientAgreementDetailsSeed(
+      val eService2Seed                = eService1Seed.copy(eserviceId = eServiceId2, descriptorId = descriptorId2)
+      val agreementSeed                = ClientAgreementDetailsSeed(
         eserviceId = eServiceId1,
         consumerId = consumerId,
         agreementId = agreementId1,
         state = ClientComponentState.ACTIVE
       )
-      val purposeSeed   = ClientPurposeDetailsSeed(
-        purposeId = purposeId1,
+      def purposeSeed(purposeId: UUID) = ClientPurposeDetailsSeed(
+        purposeId = purposeId,
         versionId = purposeVersionId1,
         state = ClientComponentState.ACTIVE
       )
 
-      val purpose1EService1Seed = PurposeSeed(
-        purposeId = purposeId1,
-        states = ClientStatesChainSeed(eservice = eService1Seed, agreement = agreementSeed, purpose = purposeSeed)
+      val purposeSeed1 = purposeSeed(purposeId1)
+      val purposeSeed2 = purposeSeed(purposeId2)
+      val purposeSeed3 = purposeSeed(purposeId3)
+
+      val purpose1EService1Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eService1Seed, agreement = agreementSeed, purpose = purposeSeed1)
       )
-      val purpose2EService1Seed = PurposeSeed(
-        purposeId = purposeId2,
-        states = ClientStatesChainSeed(eservice = eService1Seed, agreement = agreementSeed, purpose = purposeSeed)
+      val purpose2EService1Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eService1Seed, agreement = agreementSeed, purpose = purposeSeed2)
       )
 
-      val purpose3EService2Seed = PurposeSeed(
-        purposeId = purposeId3,
-        states = ClientStatesChainSeed(eservice = eService2Seed, agreement = agreementSeed, purpose = purposeSeed)
+      val purpose3EService2Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eService2Seed, agreement = agreementSeed, purpose = purposeSeed3)
       )
       // Seed
 
@@ -299,7 +296,9 @@ class PurposeManagementSpec
       )
 
       val agreementDetails = PersistentClientAgreementDetails.fromSeed(agreementSeed).toApi
-      val purposeDetails   = PersistentClientPurposeDetails.fromSeed(purposeSeed).toApi
+      val purposeDetails1  = PersistentClientPurposeDetails.fromSeed(purposeSeed1).toApi
+      val purposeDetails2  = PersistentClientPurposeDetails.fromSeed(purposeSeed2).toApi
+      val purposeDetails3  = PersistentClientPurposeDetails.fromSeed(purposeSeed3).toApi
 
       val expectedEService1State = ClientEServiceDetails(
         eserviceId = eServiceId1,
@@ -310,43 +309,39 @@ class PurposeManagementSpec
       )
 
       val expectedClient1Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId1,
             eservice = expectedEService1State,
             agreement = agreementDetails,
-            purpose = purposeDetails
+            purpose = purposeDetails1
           )
         ),
-        Purpose(
-          purposeId = purpose3EService2Seed.purposeId,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId2,
             eservice = PersistentClientEServiceDetails.fromSeed(purpose3EService2Seed.states.eservice).toApi,
             agreement = agreementDetails,
-            purpose = purposeDetails
+            purpose = purposeDetails3
           )
         )
       )
 
       val expectedClient2Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId3,
             eservice = expectedEService1State,
             agreement = agreementDetails,
-            purpose = purposeDetails
+            purpose = purposeDetails1
           )
         ),
-        Purpose(
-          purposeId = purpose2EService1Seed.purposeId,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId4,
             eservice = expectedEService1State,
             agreement = agreementDetails,
-            purpose = purposeDetails
+            purpose = purposeDetails2
           )
         )
       )
@@ -389,18 +384,22 @@ class PurposeManagementSpec
       val statesChainId4 = UUID.randomUUID()
 
       // Seed
-      val eServiceSeed = ClientEServiceDetailsSeed(
+      val eServiceSeed                 = ClientEServiceDetailsSeed(
         eserviceId = eServiceId1,
         descriptorId = descriptorId1,
         state = ClientComponentState.ACTIVE,
         audience = Seq("some.audience"),
         voucherLifespan = 10
       )
-      val purposeSeed  = ClientPurposeDetailsSeed(
-        purposeId = purposeId1,
+      def purposeSeed(purposeId: UUID) = ClientPurposeDetailsSeed(
+        purposeId = purposeId,
         versionId = purposeVersionId1,
         state = ClientComponentState.ACTIVE
       )
+
+      val purposeSeed1 = purposeSeed(purposeId1)
+      val purposeSeed2 = purposeSeed(purposeId2)
+      val purposeSeed3 = purposeSeed(purposeId3)
 
       val agreementSeed1 = ClientAgreementDetailsSeed(
         eserviceId = eServiceId1,
@@ -415,18 +414,15 @@ class PurposeManagementSpec
         state = ClientComponentState.ACTIVE
       )
 
-      val purpose1Agreement1Seed = PurposeSeed(
-        purposeId = purposeId1,
-        states = ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed1, purpose = purposeSeed)
+      val purpose1Agreement1Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed1, purpose = purposeSeed1)
       )
-      val purpose2Agreement1Seed = PurposeSeed(
-        purposeId = purposeId2,
-        states = ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed1, purpose = purposeSeed)
+      val purpose2Agreement1Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed1, purpose = purposeSeed2)
       )
 
-      val purpose3Agreement2Seed = PurposeSeed(
-        purposeId = purposeId3,
-        states = ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed2, purpose = purposeSeed)
+      val purpose3Agreement2Seed = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed2, purpose = purposeSeed3)
       )
       // Seed
 
@@ -442,7 +438,9 @@ class PurposeManagementSpec
         ClientAgreementDetailsUpdate(agreementId = UUID.randomUUID(), state = ClientComponentState.INACTIVE)
 
       val eServiceDetails = PersistentClientEServiceDetails.fromSeed(eServiceSeed).toApi
-      val purposeDetails  = PersistentClientPurposeDetails.fromSeed(purposeSeed).toApi
+      val purposeDetails1 = PersistentClientPurposeDetails.fromSeed(purposeSeed1).toApi
+      val purposeDetails2 = PersistentClientPurposeDetails.fromSeed(purposeSeed2).toApi
+      val purposeDetails3 = PersistentClientPurposeDetails.fromSeed(purposeSeed3).toApi
 
       val expectedAgreement1State =
         ClientAgreementDetails(
@@ -453,43 +451,39 @@ class PurposeManagementSpec
         )
 
       val expectedClient1Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId1,
             eservice = eServiceDetails,
             agreement = expectedAgreement1State,
-            purpose = purposeDetails
+            purpose = purposeDetails1
           )
         ),
-        Purpose(
-          purposeId = purpose3Agreement2Seed.purposeId,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId2,
             eservice = eServiceDetails,
             agreement = PersistentClientAgreementDetails.fromSeed(purpose3Agreement2Seed.states.agreement).toApi,
-            purpose = purposeDetails
+            purpose = purposeDetails3
           )
         )
       )
 
       val expectedClient2Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId3,
             eservice = eServiceDetails,
             agreement = expectedAgreement1State,
-            purpose = purposeDetails
+            purpose = purposeDetails1
           )
         ),
-        Purpose(
-          purposeId = purpose2Agreement1Seed.purposeId,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId4,
             eservice = eServiceDetails,
             agreement = expectedAgreement1State,
-            purpose = purposeDetails
+            purpose = purposeDetails2
           )
         )
       )
@@ -555,15 +549,11 @@ class PurposeManagementSpec
         state = ClientComponentState.ACTIVE
       )
 
-      val purposeSeed1 = PurposeSeed(
-        purposeId = purposeId1,
-        states =
-          ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed, purpose = purposeDetailsSeed1)
+      val purposeSeed1 = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed, purpose = purposeDetailsSeed1)
       )
-      val purposeSeed2 = PurposeSeed(
-        purposeId = purposeId2,
-        states =
-          ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed, purpose = purposeDetailsSeed2)
+      val purposeSeed2 = PurposeSeed(states =
+        ClientStatesChainSeed(eservice = eServiceSeed, agreement = agreementSeed, purpose = purposeDetailsSeed2)
       )
       // Seed
 
@@ -585,18 +575,16 @@ class PurposeManagementSpec
         ClientPurposeDetails(purposeId = purposeId1, versionId = updatePayload.versionId, state = updatePayload.state)
 
       val expectedClient1Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId1,
             eservice = eServiceDetails,
             agreement = agreementDetails,
             purpose = expectedPurpose1State
           )
         ),
-        Purpose(
-          purposeId = purposeId2,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId2,
             eservice = eServiceDetails,
             agreement = agreementDetails,
@@ -606,18 +594,16 @@ class PurposeManagementSpec
       )
 
       val expectedClient2Purposes: Seq[Purpose] = Seq(
-        Purpose(
-          purposeId = purposeId1,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId3,
             eservice = eServiceDetails,
             agreement = agreementDetails,
             purpose = expectedPurpose1State
           )
         ),
-        Purpose(
-          purposeId = purposeId2,
-          states = ClientStatesChain(
+        Purpose(states =
+          ClientStatesChain(
             id = statesChainId4,
             eservice = eServiceDetails,
             agreement = agreementDetails,

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
@@ -117,7 +117,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           id = clientUuid1,
           consumerId = consumerUuid,
           name = "client 1",
-          purposes = Map.empty,
+          purposes = Seq.empty,
           description = Some("client 1 desc"),
           relationships = Set.empty,
           kind = Consumer
@@ -127,7 +127,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           id = clientUuid2,
           consumerId = consumerUuid,
           name = "client 2",
-          purposes = Map.empty,
+          purposes = Seq.empty,
           description = Some("client 2 desc"),
           relationships = Set.empty,
           kind = Consumer
@@ -137,7 +137,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           id = clientUuid3,
           consumerId = consumerUuid,
           name = "client 3",
-          purposes = Map.empty,
+          purposes = Seq.empty,
           description = Some("client 3 desc"),
           relationships = Set.empty,
           kind = Consumer


### PR DESCRIPTION
The change impacts the `purposes` field of the client, before this PR in my opinion it was more evident that the client contained a list of purposes with attached additional information.
Now it is more subtle because the id of the purpose is actually dug inside the states.

But let me know your thoughts