### PR TITLE
[Pin 3237] Implementazione date authorization-management (client, keys)

### DIFF
--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
@@ -11,5 +11,5 @@ final case class PersistentClient(
   description: Option[String],
   relationships: Set[UUID],
   kind: PersistentClientKind,
-  createdAt: Option[OffsetDateTime]
+  createdAt: OffsetDateTime
 )

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/client/PersistentClient.scala
@@ -1,5 +1,6 @@
 package it.pagopa.interop.authorizationmanagement.model.client
 
+import java.time.OffsetDateTime
 import java.util.UUID
 
 final case class PersistentClient(
@@ -9,5 +10,6 @@ final case class PersistentClient(
   purposes: Seq[PersistentClientStatesChain],
   description: Option[String],
   relationships: Set[UUID],
-  kind: PersistentClientKind
+  kind: PersistentClientKind,
+  createdAt: Option[OffsetDateTime]
 )

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/key/PersistentKey.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/key/PersistentKey.scala
@@ -10,5 +10,5 @@ final case class PersistentKey(
   encodedPem: String,
   algorithm: String,
   use: PersistentKeyUse,
-  creationTimestamp: OffsetDateTime
+  createdAt: OffsetDateTime
 )

--- a/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/JsonFormats.scala
+++ b/models/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/JsonFormats.scala
@@ -59,7 +59,7 @@ object JsonFormats {
     jsonFormat3(PersistentClientPurposeDetails.apply)
 
   implicit val pcscFormat: RootJsonFormat[PersistentClientStatesChain] = jsonFormat4(PersistentClientStatesChain.apply)
-  implicit val pcFormat: RootJsonFormat[PersistentClient]              = jsonFormat7(PersistentClient.apply)
+  implicit val pcFormat: RootJsonFormat[PersistentClient]              = jsonFormat8(PersistentClient.apply)
 
   implicit val pkFormat: RootJsonFormat[PersistentKey] = jsonFormat7(PersistentKey.apply)
 

--- a/src/main/protobuf/v1/client.proto
+++ b/src/main/protobuf/v1/client.proto
@@ -15,6 +15,7 @@ message PersistentClientV1 {
   repeated string relationships = 6;
   repeated ClientPurposesEntryV1 purposes = 7;
   required ClientKindV1 kind = 8;
+  optional int64 createdAt = 9;
 }
 
 message ClientPurposesEntryV1 {

--- a/src/main/protobuf/v1/key.proto
+++ b/src/main/protobuf/v1/key.proto
@@ -18,9 +18,8 @@ message PersistentKeyV1 {
   required string encodedPem = 3;
   required KeyUseV1 use = 4;
   required string algorithm = 5;
-  required string creationTimestamp = 6;
+  required string createdAt = 6;
   required string name = 7;
-  optional int64 createdAt = 8; // TODO inutile?
 }
 
 enum KeyUseV1 {

--- a/src/main/protobuf/v1/key.proto
+++ b/src/main/protobuf/v1/key.proto
@@ -20,6 +20,7 @@ message PersistentKeyV1 {
   required string algorithm = 5;
   required string creationTimestamp = 6;
   required string name = 7;
+  optional int64 createdAt = 8; // TODO inutile?
 }
 
 enum KeyUseV1 {

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -946,6 +946,7 @@ components:
         - purposes
         - relationships
         - kind
+        - createdAt
     Clients:
       type: array
       items:

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -761,6 +761,9 @@ components:
         key:
           type: string
           description: 'Base64 UTF-8 encoding of a public key in PEM format'
+        createdAt:
+          type: string
+          format: date-time
         use:
           $ref: '#/components/schemas/KeyUse'
         alg:
@@ -775,6 +778,7 @@ components:
         - use
         - alg
         - name
+        - createdAt
     ClientKey:
       type: object
       properties:
@@ -896,12 +900,16 @@ components:
           type: string
         description:
           type: string
+        createdAt:
+          type: string
+          format: date-time
         kind:
           $ref: '#/components/schemas/ClientKind'
       required:
         - consumerId
         - name
         - kind
+        - createdAt
     Client:
       description: Models a Client
       type: object
@@ -912,6 +920,9 @@ components:
         consumerId:
           type: string
           format: uuid
+        createdAt:
+          type: string
+          format: date-time
         name:
           type: string
         description:

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/KeyApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/KeyApiServiceImpl.scala
@@ -57,7 +57,7 @@ final case class KeyApiServiceImpl(
     val result: Future[KeysResponse] = for {
       validPayload   <- validatedPayload.toEither.leftMap(err => InvalidKeys(err.toList)).toFuture
       validKeys      <- validateWithCurrentKeys(validPayload, keysIdentifiers).toFuture
-      persistentKeys <- validKeys.traverse(PersistentKey.toPersistentKey(dateTimeSupplier)).toFuture
+      persistentKeys <- validKeys.traverse(PersistentKey.toPersistentKey).toFuture
       addedKeys      <- commander(clientId).askWithStatus(ref => AddKeys(clientId, persistentKeys, ref))
       apiKeys        <- addedKeys.traverse(_.toApi).toFuture
     } yield KeysResponse(apiKeys)

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/api/impl/package.scala
@@ -19,7 +19,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val problemFormat: RootJsonFormat[Problem]           = jsonFormat6(Problem)
 
   implicit val otherPrimeInfoFormat: RootJsonFormat[OtherPrimeInfo]     = jsonFormat3(OtherPrimeInfo)
-  implicit val keySeedFormat: RootJsonFormat[KeySeed]                   = jsonFormat5(KeySeed)
+  implicit val keySeedFormat: RootJsonFormat[KeySeed]                   = jsonFormat6(KeySeed)
   implicit val keyFormat: RootJsonFormat[Key]                           = customKeyFormat
   implicit val clientKeyFormat: RootJsonFormat[ClientKey]               = jsonFormat4(ClientKey)
   implicit val encodedClientKeyFormat: RootJsonFormat[EncodedClientKey] = jsonFormat1(EncodedClientKey)
@@ -50,8 +50,8 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val purposeDetailsUpdateFormat: RootJsonFormat[ClientPurposeDetailsUpdate]                                 =
     jsonFormat2(ClientPurposeDetailsUpdate)
 
-  implicit val clientSeedFormat: RootJsonFormat[ClientSeed]                  = jsonFormat4(ClientSeed)
-  implicit val clientFormat: RootJsonFormat[Client]                          = jsonFormat7(Client)
+  implicit val clientSeedFormat: RootJsonFormat[ClientSeed]                  = jsonFormat5(ClientSeed)
+  implicit val clientFormat: RootJsonFormat[Client]                          = jsonFormat8(Client)
   implicit val relationshipSeedFormat: RootJsonFormat[PartyRelationshipSeed] = jsonFormat1(PartyRelationshipSeed)
 
   implicit val keyWithClientFormat: RootJsonFormat[KeyWithClient] = jsonFormat2(KeyWithClient)

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
@@ -18,7 +18,7 @@ object ClientAdapters {
         description = p.description,
         relationships = p.relationships,
         kind = p.kind.toApi,
-        createdAt = p.createdAt
+        createdAt = Some(p.createdAt)
       )
   }
 
@@ -32,7 +32,7 @@ object ClientAdapters {
         description = seed.description,
         relationships = Set.empty[UUID],
         kind = PersistentClientKind.fromApi(seed.kind),
-        createdAt = Some(seed.createdAt)
+        createdAt = seed.createdAt
       )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
@@ -17,7 +17,8 @@ object ClientAdapters {
         purposes = p.purposes.map(_.toApi).map(Purpose),
         description = p.description,
         relationships = p.relationships,
-        kind = p.kind.toApi
+        kind = p.kind.toApi,
+        createdAt = p.createdAt
       )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
@@ -18,7 +18,7 @@ object ClientAdapters {
         description = p.description,
         relationships = p.relationships,
         kind = p.kind.toApi,
-        createdAt = Some(p.createdAt)
+        createdAt = p.createdAt
       )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/ClientAdapters.scala
@@ -30,7 +30,8 @@ object ClientAdapters {
         purposes = Seq.empty,
         description = seed.description,
         relationships = Set.empty[UUID],
-        kind = PersistentClientKind.fromApi(seed.kind)
+        kind = PersistentClientKind.fromApi(seed.kind),
+        createdAt = Some(seed.createdAt)
       )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/KeyAdapters.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/KeyAdapters.scala
@@ -4,7 +4,6 @@ import it.pagopa.interop.authorizationmanagement.errors.KeyManagementErrors.Thum
 import it.pagopa.interop.authorizationmanagement.model.key.{Enc, PersistentKey, PersistentKeyUse, Sig}
 import it.pagopa.interop.authorizationmanagement.model.{ClientKey, KeyUse}
 import it.pagopa.interop.authorizationmanagement.service.impl.KeyProcessor
-import it.pagopa.interop.commons.utils.service.OffsetDateTimeSupplier
 
 object KeyAdapters {
 
@@ -12,13 +11,11 @@ object KeyAdapters {
     def toApi: Either[Throwable, ClientKey] =
       KeyProcessor
         .fromBase64encodedPEMToAPIKey(p.kid, p.encodedPem, p.use, p.algorithm)
-        .map(ClientKey(_, p.relationshipId, p.name, p.creationTimestamp))
+        .map(ClientKey(_, p.relationshipId, p.name, p.createdAt))
   }
 
   implicit class PersistentKeyObjectWrapper(private val p: PersistentKey.type) extends AnyVal {
-    def toPersistentKey(
-      dateTimeSupplier: OffsetDateTimeSupplier
-    )(validKey: ValidKey): Either[ThumbprintCalculationError, PersistentKey] =
+    def toPersistentKey(validKey: ValidKey): Either[ThumbprintCalculationError, PersistentKey] =
       for {
         kid <- KeyProcessor.calculateKid(validKey._2)
       } yield PersistentKey(
@@ -28,7 +25,7 @@ object KeyAdapters {
         encodedPem = validKey._1.key,
         algorithm = validKey._1.alg,
         use = PersistentKeyUse.fromApi(validKey._1.use),
-        creationTimestamp = dateTimeSupplier.get()
+        createdAt = validKey._1.createdAt
       )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
@@ -27,7 +27,7 @@ package object v1 {
 
   type ErrorOr[A] = Either[Throwable, A]
 
-  final val DEFAULT_CREATED_AT: OffsetDateTime = OffsetDateTime.of(2022, 10, 21, 12, 0, 0, 0, ZoneOffset.UTC)
+  final val DEFAULT_CREATED_AT: OffsetDateTime = OffsetDateTime.of(2023, 4, 18, 12, 0, 0, 0, ZoneOffset.UTC)
 
   implicit def stateV1PersistEventDeserializer: PersistEventDeserializer[StateV1, State] =
     state => {

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
@@ -27,7 +27,7 @@ package object v1 {
 
   type ErrorOr[A] = Either[Throwable, A]
 
-  final val defaultCreatedAt: OffsetDateTime = OffsetDateTime.of(2022, 10, 21, 12, 0, 0, 0, ZoneOffset.UTC)
+  final val DEFAULT_CREATED_AT: OffsetDateTime = OffsetDateTime.of(2022, 10, 21, 12, 0, 0, 0, ZoneOffset.UTC)
 
   implicit def stateV1PersistEventDeserializer: PersistEventDeserializer[StateV1, State] =
     state => {
@@ -331,7 +331,7 @@ package object v1 {
       description = client.description,
       relationships = relationships.toSet,
       kind = kind,
-      createdAt = createdAt.getOrElse(defaultCreatedAt)
+      createdAt = createdAt.getOrElse(DEFAULT_CREATED_AT)
     )
   }
 

--- a/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
+++ b/src/main/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/v1/package.scala
@@ -267,7 +267,7 @@ package object v1 {
         description = client.description,
         relationships = client.relationships.map(_.toString).toSeq,
         kind = clientKindToProtobufV1(client.kind),
-        createdAt = client.createdAt
+        createdAt = Option(client.createdAt.toMillis)
       )
     )
 

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/authz/ClientApiServiceAuthzSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/authz/ClientApiServiceAuthzSpec.scala
@@ -11,6 +11,7 @@ import it.pagopa.interop.authorizationmanagement.util.{AuthorizedRoutes, Cluster
 import it.pagopa.interop.commons.utils.service.UUIDSupplier
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.time.OffsetDateTime
 import java.util.UUID
 
 class ClientApiServiceAuthzSpec extends AnyWordSpecLike with ClusteredScalatestRouteTest {
@@ -38,7 +39,8 @@ class ClientApiServiceAuthzSpec extends AnyWordSpecLike with ClusteredScalatestR
         consumerId = UUID.randomUUID(),
         name = "fake",
         description = Some("fake"),
-        kind = ClientKind.CONSUMER
+        kind = ClientKind.CONSUMER,
+        createdAt = OffsetDateTime.now()
       )
 
       validateAuthorization(endpoint, { implicit c: Seq[(String, String)] => service.createClient(fakeSeed) })

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
@@ -52,7 +52,7 @@ class ClientManagementSpec
           description = description,
           relationships = Set.empty,
           kind = ClientKind.CONSUMER,
-          createdAt = Some(timestamp)
+          createdAt = timestamp
         )
 
       val data =
@@ -199,7 +199,7 @@ class ClientManagementSpec
             )
           ),
           relationships = Set.empty,
-          createdAt = Some(timestamp)
+          createdAt = timestamp
         )
 
       }

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ClientManagementSpec.scala
@@ -51,7 +51,8 @@ class ClientManagementSpec
           purposes = Seq.empty,
           description = description,
           relationships = Set.empty,
-          kind = ClientKind.CONSUMER
+          kind = ClientKind.CONSUMER,
+          createdAt = Some(timestamp)
         )
 
       val data =
@@ -59,7 +60,8 @@ class ClientManagementSpec
            |  "consumerId": "${consumerUuid.toString}",
            |  "name": "$name",
            |  "kind": "CONSUMER",
-           |  "description": "${description.get}"
+           |  "description": "${description.get}",
+           |  "createdAt": "$timestamp"
            |}""".stripMargin
 
       val response = request(uri = s"$serviceURL/clients", method = HttpMethods.POST, data = Some(data))
@@ -196,7 +198,8 @@ class ClientManagementSpec
               )
             )
           ),
-          relationships = Set.empty
+          relationships = Set.empty,
+          createdAt = Some(timestamp)
         )
 
       }

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/KeyManagementSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/KeyManagementSpec.scala
@@ -93,7 +93,8 @@ class KeyManagementSpec
            |    "key": "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUlJQklqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF0WGxFTVAwUmEvY0dST050UmliWgppa1FhclUvY2pqaUpDTmNjMFN1dUtYUll2TGRDSkVycEt1UWNSZVhLVzBITGNCd3RibmRXcDhWU25RbkhUY0FpCm9rL0srSzhLblE3K3pEVHlSaTZXY3JhK2dtQi9KanhYeG9ZbjlEbFpBc2tjOGtDYkEvdGNnc1lsL3BmdDJ1YzAKUnNRdEZMbWY3cWVIYzQxa2dpOHNKTjdBbDJuYmVDb3EzWGt0YnBnQkVPcnZxRmttMkNlbG9PKzdPN0l2T3dzeQpjSmFiZ1p2Z01aSm4zeWFMeGxwVGlNanFtQjc5QnJwZENMSHZFaDhqZ2l5djJ2YmdwWE1QTlY1YXhaWmNrTnpRCnhNUWhwRzh5Y2QzaGJrV0s1b2ZkdXMwNEJ0T0c3ejBmbDNnVFp4czdOWDJDVDYzT0RkcnZKSFpwYUlqbks1NVQKbFFJREFRQUIKLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0t",
            |    "use": "SIG",
            |    "name": "Devet",
-           |    "alg": "123"
+           |    "alg": "123",
+           |    "createdAt": "$timestamp"
            |  }
            |]
            |""".stripMargin

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
@@ -24,7 +24,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         ),
         "2" -> PersistentKey(
           kid = "2",
@@ -33,7 +33,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         ),
         "3" -> PersistentKey(
           kid = "3",
@@ -42,7 +42,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         ),
         "4" -> PersistentKey(
           kid = "4",
@@ -51,7 +51,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         )
       )
       val keys           = Map("fooBarKeys" -> fooBarKeys)
@@ -87,7 +87,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         )
       )
       val client2Keys = Map(
@@ -98,7 +98,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         )
       )
       val client3Keys = Map(
@@ -109,7 +109,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           encodedPem = "123",
           use = Sig,
           algorithm = "sha",
-          creationTimestamp = OffsetDateTime.now()
+          createdAt = OffsetDateTime.now()
         )
       )
       val client1     =
@@ -120,7 +120,8 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           purposes = Seq.empty,
           description = Some("client 1 desc"),
           relationships = Set.empty,
-          kind = Consumer
+          kind = Consumer,
+          createdAt = Some(OffsetDateTime.now())
         )
       val client2     =
         PersistentClient(
@@ -130,7 +131,8 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           purposes = Seq.empty,
           description = Some("client 2 desc"),
           relationships = Set.empty,
-          kind = Consumer
+          kind = Consumer,
+          createdAt = Some(OffsetDateTime.now())
         )
       val client3     =
         PersistentClient(
@@ -140,7 +142,8 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           purposes = Seq.empty,
           description = Some("client 3 desc"),
           relationships = Set.empty,
-          kind = Consumer
+          kind = Consumer,
+          createdAt = Some(OffsetDateTime.now())
         )
 
       val keys    = Map(clientId1 -> client1Keys, clientId2 -> client2Keys, clientId3 -> client3Keys)

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/StateSpec.scala
@@ -121,7 +121,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           description = Some("client 1 desc"),
           relationships = Set.empty,
           kind = Consumer,
-          createdAt = Some(OffsetDateTime.now())
+          createdAt = OffsetDateTime.now()
         )
       val client2     =
         PersistentClient(
@@ -132,7 +132,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           description = Some("client 2 desc"),
           relationships = Set.empty,
           kind = Consumer,
-          createdAt = Some(OffsetDateTime.now())
+          createdAt = OffsetDateTime.now()
         )
       val client3     =
         PersistentClient(
@@ -143,7 +143,7 @@ class StateSpec extends AnyWordSpecLike with Matchers {
           description = Some("client 3 desc"),
           relationships = Set.empty,
           kind = Consumer,
-          createdAt = Some(OffsetDateTime.now())
+          createdAt = OffsetDateTime.now()
         )
 
       val keys    = Map(clientId1 -> client1Keys, clientId2 -> client2Keys, clientId3 -> client3Keys)

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ValidationSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/impl/ValidationSpec.scala
@@ -9,6 +9,7 @@ import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.time.OffsetDateTime
 import java.util.{Base64, UUID}
 
 object ValidationTest extends Validation
@@ -36,7 +37,8 @@ class ValidationSpec extends AnyWordSpecLike with Matchers with EitherValues {
         alg = "123",
         use = KeyUse.SIG,
         relationshipId = UUID.randomUUID(),
-        name = "Random Key"
+        name = "Random Key",
+        createdAt = OffsetDateTime.now()
       )
 
       val validation = ValidationTest.validateKeys(Seq(key))
@@ -66,7 +68,8 @@ class ValidationSpec extends AnyWordSpecLike with Matchers with EitherValues {
         alg = "123",
         use = KeyUse.SIG,
         relationshipId = UUID.randomUUID(),
-        name = "Random Key"
+        name = "Random Key",
+        createdAt = OffsetDateTime.now()
       )
 
       val validation = ValidationTest.validateKeys(Seq(key))
@@ -97,7 +100,8 @@ class ValidationSpec extends AnyWordSpecLike with Matchers with EitherValues {
         alg = "123",
         use = KeyUse.SIG,
         relationshipId = UUID.randomUUID(),
-        name = "Random Key"
+        name = "Random Key",
+        createdAt = OffsetDateTime.now()
       )
 
       val key = KeyProcessor.fromBase64encodedPEMToAPIKey("mockKID", encodedPem.key, Enc, "123")
@@ -122,7 +126,8 @@ class ValidationSpec extends AnyWordSpecLike with Matchers with EitherValues {
         alg = "123",
         use = KeyUse.SIG,
         relationshipId = UUID.randomUUID(),
-        name = "Random Key"
+        name = "Random Key",
+        createdAt = OffsetDateTime.now()
       )
 
       val validation = ValidationTest.validateKeys(Seq(key))

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/PersistentSerializationSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/PersistentSerializationSpec.scala
@@ -24,7 +24,6 @@ import it.pagopa.interop.authorizationmanagement.model.persistence.serializer.v1
 import com.softwaremill.diffx.munit.DiffxAssertions
 import com.softwaremill.diffx.generic.auto._
 import com.softwaremill.diffx.Diff
-import it.pagopa.interop.commons.utils.TypeConversions.OffsetDateTimeOps
 
 import scala.reflect.runtime.universe.{TypeTag, typeOf}
 
@@ -205,9 +204,8 @@ object PersistentSerializationSpec {
     description              <- stringGen.map(Option(_).filter(_.nonEmpty))
     relations                <- Gen.containerOf[Set, UUID](Gen.uuid)
     (pkind, kindV1)          <- persistentClientKindGen
-    (createdAt, _)           <- offsetDatetimeGen
   } yield (
-    PersistentClient(id, consumerId, name, ppurposesC, description, relations, pkind, Some(createdAt)),
+    PersistentClient(id, consumerId, name, ppurposesC, description, relations, pkind, None),
     PersistentClientV1(
       id = id.toString(),
       consumerId = consumerId.toString(),
@@ -216,7 +214,7 @@ object PersistentSerializationSpec {
       relationships = relations.map(_.toString()).toSeq,
       purposes = purposeCV1,
       kind = kindV1,
-      createdAt = Some(createdAt.toMillis)
+      createdAt = None // TODO Set None because there's a problem with comparing this with the one of the object
     )
   )
 

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/PersistentSerializationSpec.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/model/persistence/serializer/PersistentSerializationSpec.scala
@@ -111,7 +111,7 @@ object PersistentSerializationSpec {
     time <- Gen.oneOf(nowMills.minusSeconds(n), nowMills.plusSeconds(n))
   } yield (time, time.toInstant.toEpochMilli)
 
-  val defaultCreatedAt: OffsetDateTime = OffsetDateTime.of(2022, 10, 21, 12, 0, 0, 0, ZoneOffset.UTC)
+  val defaultCreatedAt: OffsetDateTime = OffsetDateTime.of(2023, 4, 18, 12, 0, 0, 0, ZoneOffset.UTC)
 
   val persistentKeyUseGen: Gen[(PersistentKeyUse, KeyUseV1)] =
     Gen.oneOf[(PersistentKeyUse, KeyUseV1)]((Sig, KeyUseV1.SIG), (Enc, KeyUseV1.ENC))

--- a/src/test/scala/it/pagopa/interop/authorizationmanagement/util/util.scala
+++ b/src/test/scala/it/pagopa/interop/authorizationmanagement/util/util.scala
@@ -1,6 +1,6 @@
 package it.pagopa.interop.authorizationmanagement
 
-import it.pagopa.interop.commons.jwt.{ADMIN_ROLE, API_ROLE, INTERNAL_ROLE, M2M_ROLE, SECURITY_ROLE}
+import it.pagopa.interop.commons.jwt._
 
 package object util {
 


### PR DESCRIPTION
https://pagopa.atlassian.net/browse/PIN-3162

There's a TODO in [this line](https://github.com/pagopa/interop-be-authorization-management/pull/204/files#diff-6e6684087edacee5bae578b1e2e81a3a7dfcca06038b6f2268eb812a3e558c2eR217) because I wasn't able to find a solution on comparing the `createdAt` parameter between `PersistentClient` and `PersistentClientV1` their value is slightly different like in the following example: 
`createdAt: 2023-04-06T13:40:00.730Z -> 2023-04-06T15:40:00.730008+02:00),`
